### PR TITLE
Use done status to mark end of message seq

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: node_js
+sudo: false
 
 node_js:
   - "0.10"
+  - "4.2"
 
 before_script:
   - wget https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
   "license": "MIT",
   "dependencies": {
     "bencode": "~0.7.0",
-    "tree-kill": "~0.0.6"
+    "tree-kill": "~1.0.0"
   },
   "devDependencies": {
-    "async": "~0.9",
-    "nodeunit": "~0.8"
+    "q": "~1.4.1",
+    "nodeunit": "~0.9.1"
   }
 }

--- a/src/nrepl-client.js
+++ b/src/nrepl-client.js
@@ -121,8 +121,9 @@ function nreplSend(socket, messageStream, msgSpec, callback) {
 
     function errHandler(err) { errors.push(err); }
     function msgHandler(_messages) {
-        var done = _messages.some(function(msg) { return !!msg.status; });
-            // return msg.status && msg.status.indexOf("done") > -1; });
+        var done = _messages.some(function(msg) {
+            return msg.status && msg.status.indexOf("done") > -1;
+        });
         messages = messages.concat(_messages);
         if (!done) return;
         messageStream.removeListener('error', errHandler);

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -2,7 +2,7 @@
 
 var nreplClient = require('../src/nrepl-client');
 var nreplServer = require('../src/nrepl-server');
-var async = require("async");
+var Q = require('q');
 
 var exec = require("child_process").exec;
 
@@ -22,21 +22,18 @@ function createTimeout(test) {
 var tests = {
 
     setUp: function (callback) {
-        async.waterfall([
-            function(next) { nreplServer.start(serverOpts, next); },
-            function(serverState, next) {
-                server = serverState;
-                client = nreplClient.connect({
-                    port: serverState.port,
-                    verbose: true
-                });
-                console.log("client connecting");
-                client.once('connect', function() {
-                    console.log("client connected");
-                    next();
-                });
-            }
-        ], callback);
+        Q.ninvoke(nreplServer, 'start', serverOpts).then(function (serverState) {
+            server = serverState;
+            client = nreplClient.connect({
+                port: serverState.port,
+                verbose: true
+            });
+            console.log("client connecting");
+            return Q.ninvoke(client, 'once', 'connect');
+        }).then(function () {
+            console.log("client connected");
+            callback();
+        }).done();
     },
 
     tearDown: function (callback) {
@@ -52,16 +49,23 @@ var tests = {
         client.end();
     },
 
-    testSimpleEval: function (test) {
-        test.expect(3); createTimeout(test);
-        client.eval('(+ 3 4)', function(err, messages) {
-            console.log("in simple eval");
-            console.log(messages);
-            test.ok(!err, 'Got errors: ' + err);
+    testEval: function (test) {
+        createTimeout(test);
+        Q.ninvoke(client, 'eval', '(+ 3 4)').then(function(messages) {
             test.equal(messages[0].value, '7');
             test.deepEqual(messages[1].status, ['done']);
+            return Q.ninvoke(client, 'eval', '(throw (RuntimeException. "foo"))');
+        }).then(function (messages) {
+            test.equal(messages.length, 3);
+            test.equal(messages[0].ex, 'class java.lang.RuntimeException');
+            test.deepEqual(messages[0].status, ['eval-error']);
+            test.ok(/^RuntimeException foo/.test(messages[1].err));
+            test.deepEqual(messages[2].status, ['done']);
+        }).fail(function (err) {
+            test.ok(!err, 'Got errors: ' + err);
+        }).fin(function () {
             test.done();
-        });
+        }).done();
     }
 };
 


### PR DESCRIPTION
Seem `done` marks the end of a message seq: <https://github.com/clojure/tools.nrepl/blob/master/src/main/clojure/clojure/tools/nrepl.clj#L86>.

Currently if the response contains `eval-error` there will be some messages (the stack trace and the `done`) not appended to the buffer.  Please advice if there is special reason why that code was commented out.